### PR TITLE
Add handwritten setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 __pycache__/
 *.pyc
 .venv/
+build/
+*.egg-info/
 
 # Editors
 .idea/

--- a/BUILD
+++ b/BUILD
@@ -5,3 +5,34 @@
 # `python_requirement_library` target. Refer to
 # https://www.pantsbuild.org/docs/python-third-party-dependencies.
 python_requirements(name="reqs")
+
+python_sources(
+    name="setup-py",
+    sources=["setup.py"],
+)
+
+# to copy helloworld/greet/translations.json
+resource(
+    name="MANIFEST",
+    source="MANIFEST.in",
+)
+
+python_distribution(
+    name="say-hello",
+    dependencies=[
+        ":setup-py",
+        ":MANIFEST",
+        "helloworld:pex_binary"
+# because we depend on helloworld:pex_binary,
+# there is no need to provide all dependencies manually, e.g.
+#        "helloworld:lib",
+#        "helloworld/greet:lib",
+#        "helloworld/greet:translations",
+#        "helloworld/translator:lib",
+        ],
+    provides=python_artifact(
+        name="say-hello",
+    ),
+    generate_setup=False,
+    sdist=False,
+)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include helloworld/greet/translations.json

--- a/helloworld/translator/BUILD
+++ b/helloworld/translator/BUILD
@@ -17,14 +17,14 @@ python_tests(
 # Because this target has no source code, Pants cannot infer dependencies. We depend on `:lib`,
 #  which means we'll include all the non-test Python files in this directory, and any of
 #  their dependencies.
-python_distribution(
-    name="dist",
-    dependencies=[":lib"],
-    wheel=True,
-    sdist=True,
-    provides=setup_py(
-        name="helloworld.translator",
-        version="0.0.1",
-        description="A language translator.",
-    ),
-)
+#python_distribution(
+#    name="dist",
+#    dependencies=[":lib"],
+#    wheel=True,
+#    sdist=True,
+#    provides=setup_py(
+#        name="helloworld.translator",
+#        version="0.0.1",
+#        description="A language translator.",
+#    ),
+#)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+from setuptools import find_packages, setup
+
+setup(
+    name="say-hello",
+    packages=find_packages(),
+    entry_points={
+        "console_scripts": [
+            "say-hello = helloworld.main:say_hello",
+        ],
+    },
+    include_package_data=True,
+    version="1.0",
+    install_requires=["ansicolors"],
+)


### PR DESCRIPTION
Commit 1: missing the `helloworld/translator` directory because it's owned by another `python_distribution`.

```
Archive:  say_hello-1.0-py3-none-any.whl
  inflating: helloworld/__init__.py  
  inflating: helloworld/main.py      
  inflating: helloworld/greet/__init__.py  
  inflating: helloworld/greet/greeting.py  
  inflating: helloworld/greet/translations.json 
```

Commit 2: the final wheel is complete, because the `python_distribution` is removed.

```
Archive:  say_hello-1.0-py3-none-any.whl
  inflating: helloworld/__init__.py  
  inflating: helloworld/main.py      
  inflating: helloworld/greet/__init__.py  
  inflating: helloworld/greet/greeting.py  
  inflating: helloworld/greet/translations.json  
  inflating: helloworld/translator/__init__.py  
  inflating: helloworld/translator/translator.py  
```

---

The `pex_binary` does depend on the `helloworld/translator` and is indeed picked up unless there is a `python_distribution` that owns it.

```
$ ./pants dependencies --transitive helloworld:pex_binary
//:reqs#ansicolors
//:reqs#setuptools
//:reqs#types-setuptools
//requirements.txt:reqs
helloworld/greet/greeting.py:lib
helloworld/greet:translations
helloworld/main.py:lib
helloworld/translator/translator.py:lib
```