### PR TITLE
Infer dependencies on pytest plugins with string infer

### DIFF
--- a/helloworld/BUILD
+++ b/helloworld/BUILD
@@ -6,6 +6,8 @@ python_sources(
     name="lib",
 )
 
+python_test_utils()
+
 # This target allows us to bundle our app into a PEX binary file via
 #  `./pants package`. We can also run it with `./pants run`. See
 #  https://www.pantsbuild.org/docs/python-package-goal and

--- a/helloworld/conftest.py
+++ b/helloworld/conftest.py
@@ -1,2 +1,2 @@
 pytest_plugins = ["helloworld.plugins.handy"]
-collect_ignore = ["translator/"]
+collect_ignore = ["translator"]

--- a/helloworld/conftest.py
+++ b/helloworld/conftest.py
@@ -1,1 +1,2 @@
 pytest_plugins = ["helloworld.plugins.handy"]
+collect_ignore = ["translator/"]

--- a/helloworld/conftest.py
+++ b/helloworld/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ["helloworld.plugins.handy"]

--- a/helloworld/greet/greeting_test.py
+++ b/helloworld/greet/greeting_test.py
@@ -7,3 +7,7 @@ from helloworld.greet.greeting import Greeter
 def test_greeter() -> None:
     greeter = Greeter(translations={"hello": {"es": "hola"}})
     assert greeter.greet("test") == "Hola, test!"
+
+
+def test_string_infer(simple_fixture) -> None:
+    assert simple_fixture == "hello"

--- a/helloworld/plugins/BUILD
+++ b/helloworld/plugins/BUILD
@@ -1,0 +1,1 @@
+python_test_utils(sources=["handy.py"])

--- a/helloworld/plugins/handy.py
+++ b/helloworld/plugins/handy.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture
+def simple_fixture():
+    return "hello"

--- a/pants.toml
+++ b/pants.toml
@@ -69,3 +69,6 @@ org = "example-python"
 
 [buildsense]
 enable = false
+
+[python-infer]
+string_imports = true


### PR DESCRIPTION
```
❯ ./pants dependencies --transitive helloworld/greet/greeting_test.py
22:45:20.88 [INFO] Initializing scheduler...
22:45:21.01 [INFO] Scheduler initialized.
//:reqs#pytest
//:reqs#setuptools
//:reqs#types-setuptools
//requirements.txt:reqs
helloworld/conftest.py
helloworld/greet/greeting.py:lib
helloworld/greet:translations
helloworld/plugins/handy.py
helloworld/translator/translator.py:lib
```

`helloworld/plugins/handy.py` is picked up due to string infer.

---

```
❯ pytest helloworld --fixtures
------------------------------------------------------------------------------------- fixtures defined from helloworld.plugins.handy --------------------------------------------------------------------------------------
simple_fixture
    helloworld/plugins/handy.py:5: no docstring available
```

```
❯ pytest helloworld --trace-config | grep hello
PLUGIN registered: <module 'helloworld.conftest' from '/home/alexey.tereshenkov/code/example-python/helloworld/conftest.py'>
PLUGIN registered: <module 'helloworld.plugins.handy' from '/home/alexey.tereshenkov/code/example-python/helloworld/plugins/handy.py'>
    /home/alexey.tereshenkov/code/example-python/helloworld/conftest.py: /home/alexey.tereshenkov/code/example-python/helloworld/conftest.py
    helloworld.plugins.handy: /home/alexey.tereshenkov/code/example-python/helloworld/plugins/handy.py
helloworld/greet/greeting_test.py ..                                     [ 40%]
helloworld/translator/translator_test.py ...                             [100%]
```
